### PR TITLE
Add a junit event generator for test results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-ES-Logger [![Build Status](https://travis-ci.org/CiscoDevNet/es-logger.svg?branch=master)](https://travis-ci.org/CiscoDevNet/es-logger)
+ES-Logger [![Build Status](https://travis-ci.org/CiscoDevNet/es-logger.svg?branch=master)](https://travis-ci.org/CiscoDevNet/es-logger) [![PyPi](https://img.shields.io/pypi/v/es-logger.svg)](https://pypi.org/project/es-logger/)
+
 =========
 
 The es-logger project intends to build a pluggable data processor that will take data from

--- a/es_logger/__init__.py
+++ b/es_logger/__init__.py
@@ -13,30 +13,29 @@ import requests
 from stevedore import driver, ExtensionManager
 
 # Monkey patch the jenkins import
-from six.moves.urllib.error import HTTPError
-from six.moves.urllib.request import Request
 BUILD_ENV_VARS = '%(folder_url)sjob/%(short_name)s/%(number)d/injectedEnvVars/api/json' + \
     '?depth=%(depth)s'
 
 
 def get_build_env_vars(self, name, number, depth=0):
-    '''Get build information dictionary.
+    '''Get build environment variables.
 
     :param name: Job name, ``str``
     :param name: Build number, ``int``
+    :param depth: JSON depth, ``int``
     :returns: dictionary of build env vars, ``dict``
     '''
     folder_url, short_name = self._get_job_folder(name)
     try:
-        response = self.jenkins_open(Request(
-                self._build_url(BUILD_ENV_VARS, locals())
+        response = self.jenkins_open(requests.Request(
+                'GET', self._build_url(BUILD_ENV_VARS, locals())
             ))
         if response:
             return json.loads(response)
         else:
             raise jenkins.JenkinsException('job[%s] number[%d] does not exist'
                                            % (name, number))
-    except HTTPError:
+    except requests.exceptions.HTTPError:
         raise jenkins.JenkinsException('job[%s] number[%d] does not exist'
                                        % (name, number))
     except ValueError:
@@ -54,8 +53,7 @@ jenkins.Jenkins.get_build_env_vars = get_build_env_vars
 
 
 # Get Test results
-BUILD_TEST_REPORT = \
-    '%(folder_url)sjob/%(short_name)s/%(number)d/testReport/api/json' + \
+BUILD_TEST_REPORT = '%(folder_url)sjob/%(short_name)s/%(number)d/testReport/api/json' + \
     '?depth=%(depth)s'
 
 
@@ -68,15 +66,15 @@ def get_build_test_report(self, name, number, depth=0):
     '''
     folder_url, short_name = self._get_job_folder(name)
     try:
-        response = self.jenkins_open(Request(
-                self._build_url(BUILD_TEST_REPORT, locals())
+        response = self.jenkins_open(requests.Request(
+                'GET', self._build_url(BUILD_TEST_REPORT, locals())
             ))
         if response:
             return json.loads(response)
         else:
             raise jenkins.JenkinsException('job[%s] number[%d] does not exist'
                                            % (name, number))
-    except HTTPError:
+    except requests.exceptions.HTTPError:
         raise jenkins.JenkinsException('job[%s] number[%d] does not exist'
                                        % (name, number))
     except ValueError:

--- a/es_logger/__init__.py
+++ b/es_logger/__init__.py
@@ -127,7 +127,7 @@ class EsLogger(object):
         self.jenkins_url = self.get_jenkins_url()
         self.jenkins_user = self.get_jenkins_user()
         self.jenkins_password = self.get_jenkins_password()
-        if self.jenkins_user and self.jenkins_password:
+        if self.jenkins_url:
             self.server = jenkins.Jenkins(self.jenkins_url,
                                           username=self.jenkins_user,
                                           password=self.jenkins_password)

--- a/es_logger/interface.py
+++ b/es_logger/interface.py
@@ -57,7 +57,6 @@ class EventGenerator(object):
             * Pushing events for individual test runs
             * Pushing per-host data from a job that affects multiple hosts
     """
-
     # The default Jenkins fields to add to the generated events
     DEFAULT_FIELDS = [
         'BUILD_NUMBER',

--- a/es_logger/plugins/__init__.py
+++ b/es_logger/plugins/__init__.py
@@ -1,0 +1,4 @@
+# Copyright (c) 2018 Cisco Systems, Inc.
+# All rights reserved.
+
+__author__ = 'jonpsull'

--- a/es_logger/plugins/ansible.py
+++ b/es_logger/plugins/ansible.py
@@ -5,7 +5,7 @@ __author__ = 'jonpsull'
 
 import itertools
 import logging
-from .plugins import EventGenerator
+from ..interface import EventGenerator
 import re
 
 LOGGER = logging.getLogger(__name__)

--- a/es_logger/plugins/commit.py
+++ b/es_logger/plugins/commit.py
@@ -3,7 +3,7 @@
 
 __author__ = 'jonpsull'
 
-from .plugins import EventGenerator
+from ..interface import EventGenerator
 
 
 class CommitEvent(EventGenerator):

--- a/es_logger/plugins/junit.py
+++ b/es_logger/plugins/junit.py
@@ -1,0 +1,70 @@
+__author__ = 'jonpsull'
+
+from ..interface import EventGenerator
+import logging
+
+LOGGER = logging.getLogger(__name__)
+
+
+class JUnitEvent(EventGenerator):
+    """
+    Process the tng output
+    """
+    def get_fields(self):
+        return super(JUnitEvent, self).get_fields() + ['GERRIT_PATCHSET_REVISION',
+                                                       'GERRIT_REFSPEC']
+
+    def generate_events(self, esl):
+        """
+        return a list of objects to send as events
+
+        :param esl: the calling es_logger object
+        :type console_log: object
+        :returns: list(dict(str:?))
+        """
+        LOGGER.debug("Starting: {}".format(type(self).__name__))
+        output_list = []
+
+        # Get the test report from Jenkins (if not already cached)
+        test_report = esl.get_test_report()
+        if test_report is not None:
+            # Annotate the return with extra info
+            test_report['type'] = 'total'
+            test_report['totalCount'] = test_report['failCount'] +\
+                test_report['skipCount'] + test_report['passCount']
+
+            # Remove the suites, and process them as individual events
+            test_suites = test_report.pop("suites")
+            # Iterate and add 1 event per suite
+            for suite in test_suites:
+                test_cases = suite.pop("cases")
+                suite_name = suite['name']
+                suite_pass = 0
+                suite_skip = 0
+                suite_fail = 0
+                suite_unknown = 0
+                # Iterate and add 1 event per case
+                for case in test_cases:
+                    case['suite'] = suite_name
+                    if case['status'] == 'PASSED':
+                        suite_pass += 1
+                    elif case['status'] == 'SKIPPED':
+                        suite_skip += 1
+                    elif case['status'] == 'FAILED':
+                        suite_fail += 1
+                    else:
+                        suite_unknown += 1
+                    case['type'] = 'case'
+                    output_list.append(case)
+                suite['passCount'] = suite_pass
+                suite['skipCount'] = suite_skip
+                suite['failCount'] = suite_fail
+                suite['unknownCount'] = suite_unknown
+                suite['totalCount'] = suite_pass + suite_skip + suite_fail + suite_unknown
+                suite['type'] = 'suite'
+                output_list.append(suite)
+
+            # Add our overall result as an event
+            output_list.append(test_report)
+        LOGGER.debug("Finished: {}".format(type(self).__name__))
+        return output_list

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     keywords='jenkins development elasticsearch logstash build',
 
     install_requires=[
-        'python-jenkins',
+        'python-jenkins>=1.0.0',
         'requests',
         'stevedore',
     ],

--- a/setup.py
+++ b/setup.py
@@ -70,8 +70,9 @@ setup(
         'es_logger.plugins.gather_build_data': [
         ],
         'es_logger.plugins.event_generator': [
-            'commit = es_logger.event_generator:CommitEvent',
-            'ansible_recap_v2 = es_logger.ansible:AnsibleRecapEvent',
+            'commit = es_logger.plugins.commit:CommitEvent',
+            'ansible_recap_v2 = es_logger.plugins.ansible:AnsibleRecapEvent',
+            'junit = es_logger.plugins.junit:JUnitEvent',
         ],
     },
 

--- a/test/test_ansible.py
+++ b/test/test_ansible.py
@@ -9,10 +9,10 @@ import unittest.mock
 
 
 class TestAnsibleRecapEvent(object):
-    def test_event_generator_plugins(self):
-        eg = es_logger.ansible.AnsibleRecapEvent()
+    def test_ansible_recap_event(self):
+        eg = es_logger.plugins.ansible.AnsibleRecapEvent()
         fields = eg.get_fields()
-        nose.tools.ok_(fields == es_logger.plugins.EventGenerator.DEFAULT_FIELDS)
+        nose.tools.ok_(fields == es_logger.interface.EventGenerator.DEFAULT_FIELDS)
         esl = unittest.mock.MagicMock()
         esl.console_log = '''
 + ansible-playbook command

--- a/test/test_commit.py
+++ b/test/test_commit.py
@@ -9,10 +9,10 @@ import unittest.mock
 
 
 class TestCommitEvent(object):
-    def test_event_generator_plugins(self):
-        eg = es_logger.event_generator.CommitEvent()
+    def test_commit_event(self):
+        eg = es_logger.plugins.commit.CommitEvent()
         fields = eg.get_fields()
-        nose.tools.ok_(fields == es_logger.plugins.EventGenerator.DEFAULT_FIELDS)
+        nose.tools.ok_(fields == es_logger.interface.EventGenerator.DEFAULT_FIELDS)
         esl = unittest.mock.MagicMock()
         esl.build_info = {
                 "changeSet": {

--- a/test/test_es_logger.py
+++ b/test/test_es_logger.py
@@ -49,7 +49,8 @@ class TestEsLogger(object):
         with unittest.mock.patch('es_logger.Request'), \
                 unittest.mock.patch('jenkins.Request'), \
                 unittest.mock.patch('jenkins.urlopen') as mock_urlopen:
-            mock_urlopen().read.side_effect = HTTPError('url', 'code', 'msg', 'hdrs', 'fp')
+            mock_urlopen().read.side_effect = HTTPError('url', 'code', 'msg', 'hdrs',
+                                                        unittest.mock.MagicMock())
             self.esl.server.crumb = False
             func = getattr(self.esl.server, param)
             nose.tools.assert_raises(JenkinsException,

--- a/test/test_junit.py
+++ b/test/test_junit.py
@@ -1,0 +1,90 @@
+# Copyright (c) 2018 Cisco Systems, Inc.
+# All rights reserved.
+
+__author__ = 'jonpsull'
+
+import es_logger
+import nose
+import unittest.mock
+
+
+class TestJUnitEvent(object):
+    def test_junit_fields(self):
+        eg = es_logger.plugins.junit.JUnitEvent()
+        fields = eg.get_fields()
+        nose.tools.ok_(fields != es_logger.interface.EventGenerator.DEFAULT_FIELDS)
+
+    def test_no_test_report(self):
+        eg = es_logger.plugins.junit.JUnitEvent()
+        esl = unittest.mock.MagicMock()
+        esl.get_test_report.return_value = None
+        events = eg.generate_events(esl)
+        nose.tools.ok_(len(events) == 0)
+
+    def test_with_test_report(self):
+        eg = es_logger.plugins.junit.JUnitEvent()
+        esl = unittest.mock.MagicMock()
+        esl.get_test_report.return_value = {
+            "_class": "hudson.tasks.junit.TestResult", "testActions": [], "duration": 4550245900,
+            "empty": False, "failCount": 2, "passCount": 1, "skipCount": 1, "suites": [{
+                "cases": [{
+                    "testActions": [], "age": 0, "className": "com.test.one.Test",
+                    "duration": 0.638, "errorDetails": None, "errorStackTrace": None,
+                    "failedSince": 0, "name": "testone", "skipped": False,
+                    "skippedMessage": None, "status": "PASSED", "stderr": "", "stdout": ""
+                }, {
+                    "testActions": [], "age": 0, "className": "com.test.two.Test",
+                    "duration": 0.053, "errorDetails": None, "errorStackTrace": None,
+                    "failedSince": 0, "name": "testtwo", "skipped": False, "skippedMessage": None,
+                    "status": "SKIPPED", "stderr": "", "stdout": ""
+                }, {
+                    "testActions": [], "age": 0, "className": "com.test.three.Test",
+                    "duration": 0.053, "errorDetails": None, "errorStackTrace": None,
+                    "failedSince": 0, "name": "testthree", "skipped": False,
+                    "skippedMessage": None, "status": "FAILED", "stderr": "", "stdout": ""
+                }],
+                "duration": 1516748670, "id": None, "name": "com.suite.one.Suite", "stderr": "",
+                "stdout": "", "timestamp": "1970-01-01T00:00:00"
+            }, {
+                "cases": [{
+                    "testActions": [], "age": 0, "className": "com.test.three.Test",
+                    "duration": 0.551, "errorDetails": None, "errorStackTrace": None,
+                    "failedSince": 0, "name": "testfour", "skipped": False, "skippedMessage": None,
+                    "status": "REGRESSION", "stderr": "", "stdout": ""
+                }],
+                "duration": 0.551, "id": None, "name": "com.suite.two.Suite", "stderr": "",
+                "stdout": "", "timestamp": "2018-01-23T23:05:17"
+            }]}
+        events = eg.generate_events(esl)
+        nose.tools.ok_(len(events) == 7,
+                       "Wrong number of events returned ({}): {}".format(len(events), events))
+        results = [
+            {'testActions': [], 'age': 0, 'className': 'com.test.one.Test', 'duration': 0.638,
+             'errorDetails': None, 'errorStackTrace': None, 'failedSince': 0, 'name': 'testone',
+             'skipped': False, 'skippedMessage': None, 'status': 'PASSED', 'stderr': '',
+             'stdout': '', 'suite': 'com.suite.one.Suite', 'type': 'case'},
+            {'testActions': [], 'age': 0, 'className': 'com.test.two.Test', 'duration': 0.053,
+             'errorDetails': None, 'errorStackTrace': None, 'failedSince': 0, 'name': 'testtwo',
+             'skipped': False, 'skippedMessage': None, 'status': 'SKIPPED', 'stderr': '',
+             'stdout': '', 'suite': 'com.suite.one.Suite', 'type': 'case'},
+            {'testActions': [], 'age': 0, 'className': 'com.test.three.Test', 'duration': 0.053,
+             'errorDetails': None, 'errorStackTrace': None, 'failedSince': 0, 'name': 'testthree',
+             'skipped': False, 'skippedMessage': None, 'status': 'FAILED', 'stderr': '',
+             'stdout': '', 'suite': 'com.suite.one.Suite', 'type': 'case'},
+            {'duration': 1516748670, 'id': None, 'name': 'com.suite.one.Suite', 'stderr': '',
+             'stdout': '', 'timestamp': '1970-01-01T00:00:00', 'passCount': 1, 'skipCount': 1,
+             'failCount': 1, 'unknownCount': 0, 'totalCount': 3, 'type': 'suite'},
+            {'testActions': [], 'age': 0, 'className': 'com.test.three.Test', 'duration': 0.551,
+             'errorDetails': None, 'errorStackTrace': None, 'failedSince': 0, 'name': 'testfour',
+             'skipped': False, 'skippedMessage': None, 'status': 'REGRESSION', 'stderr': '',
+             'stdout': '', 'suite': 'com.suite.two.Suite', 'type': 'case'},
+            {'duration': 0.551, 'id': None, 'name': 'com.suite.two.Suite', 'stderr': '',
+             'stdout': '', 'timestamp': '2018-01-23T23:05:17', 'passCount': 0, 'skipCount': 0,
+             'failCount': 0, 'unknownCount': 1, 'totalCount': 1, 'type': 'suite'},
+            {'_class': 'hudson.tasks.junit.TestResult', 'testActions': [], 'duration': 4550245900,
+             'empty': False, 'failCount': 2, 'passCount': 1, 'skipCount': 1, 'type': 'total',
+             'totalCount': 4}]
+
+        for idx, event in enumerate(events):
+            nose.tools.ok_(event == results[idx],
+                           "Bad event[{}] returned: {}".format(idx, events))

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -7,7 +7,7 @@ import es_logger
 import nose
 
 
-class DummyConsoleLogProcessor(es_logger.plugins.ConsoleLogProcessor):
+class DummyConsoleLogProcessor(es_logger.interface.ConsoleLogProcessor):
     def __init__(self):
         super().__init__()
 
@@ -15,7 +15,7 @@ class DummyConsoleLogProcessor(es_logger.plugins.ConsoleLogProcessor):
         return {'DummyConsoleLogProcessor': True}
 
 
-class DummyGatherBuildData(es_logger.plugins.GatherBuildData):
+class DummyGatherBuildData(es_logger.interface.GatherBuildData):
     def __init__(self):
         super().__init__()
 
@@ -23,7 +23,7 @@ class DummyGatherBuildData(es_logger.plugins.GatherBuildData):
         return {'DummyGatherBuildData': True}
 
 
-class DummyEventGenerator(es_logger.plugins.EventGenerator):
+class DummyEventGenerator(es_logger.interface.EventGenerator):
     def __init__(self):
         super().__init__()
 
@@ -44,5 +44,5 @@ class TestPlugins(object):
     def test_event_generator_plugins(self):
         eg = DummyEventGenerator()
         fields = eg.get_fields()
-        nose.tools.ok_(fields == es_logger.plugins.EventGenerator.DEFAULT_FIELDS)
+        nose.tools.ok_(fields == es_logger.interface.EventGenerator.DEFAULT_FIELDS)
         eg.generate_events({'es_logger': True})


### PR DESCRIPTION
Add a plugin to process the test results that can be stored against a Jenkins job.

Also reorganise the plugins to separate them somewhat from the main code.

Make a minor correction in the monkey patch testing to prevent exceptions post-test.