### PR TITLE
Enable asynchronous sends of events

### DIFF
--- a/es_logger/__init__.py
+++ b/es_logger/__init__.py
@@ -156,7 +156,6 @@ class EsLogger(object):
         for target in targets:
             self.targets.append(driver.DriverManager(namespace='es_logger.plugins.event_target',
                                                      invoke_on_load=True, name=target))
-            print(self.targets[-1].driver)
         LOGGER.info('Using targets: {}'.format(targets))
 
     ####################################
@@ -397,5 +396,11 @@ class EsLogger(object):
         status = 0
         for target in self.targets:
             status += target.driver.send_event(json_event)
+        return status
+
+    def finish(self):
+        status = 0
+        for target in self.targets:
+            status += target.driver.finish_send()
             print(status)
         return status

--- a/es_logger/cli.py
+++ b/es_logger/cli.py
@@ -46,12 +46,16 @@ Target Variables:
     parser.add_argument('-c', '--console-length', type=int, default=32500)
     parser.add_argument('-e', '--events-only', action='store_true')
     parser.add_argument('-p', '--list-plugins', action='store_true')
-    parser.add_argument('-t', '--target', action='append', default=['logstash'])
+    parser.add_argument('-t', '--target', action='append',
+                        help='Target to post to, default is logstash')
 
     parser.add_argument(
         '--debug', action='store_true', help='Print debug logs to console during execution')
 
-    return parser.parse_args()
+    args = parser.parse_args()
+    if args.target is None:
+        args.target = ['logstash']
+    return args
 
 
 def configure_logging(args):
@@ -86,5 +90,8 @@ def main():
             esl.dump(e)
         if not args.no_post:
             status += esl.post(e)
+
+    if not args.no_post:
+        status += esl.finish()
 
     sys.exit(status)

--- a/es_logger/interface.py
+++ b/es_logger/interface.py
@@ -113,3 +113,6 @@ class EventTarget(object):
         :type json_event: dict
         :returns: int
         """
+
+    def finish_send(self):
+        return 0

--- a/run_tests.bash
+++ b/run_tests.bash
@@ -6,11 +6,4 @@
 export PATH=${PATH}:~/.local/bin
 pip install -q --user -r test-requirements.txt
 
-TOXENV=flake8
-for version in $(sed -n 's/[[:space:]]*- python:\(.*\)/\1/pg' .travis.yml | tr -d ' ')
-do
-    [[ -s "$(which python$version)" ]] && \
-        TOXENV=${TOXENV}${TOXENV:+,}py$(echo $version | tr -d '.')
-done
-
-TOXENV=$TOXENV $HOME/.local/bin/tox --workdir /tmp
+$HOME/.local/bin/tox --workdir /tmp

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -25,6 +25,7 @@ class TestCli(object):
         mock_es_info = unittest.mock.MagicMock()
         mock_esl(console_length=DEFAULT_CONSOLE_LENGTH, targets=[]).es_info = mock_es_info
         mock_esl(console_length=DEFAULT_CONSOLE_LENGTH, targets=[]).post.return_value = 0
+        mock_esl(console_length=DEFAULT_CONSOLE_LENGTH, targets=[]).finish.return_value = 0
         mock_esl(console_length=DEFAULT_CONSOLE_LENGTH, targets=[]).events = [mock_event,
                                                                               mock_event]
         with unittest.mock.patch('sys.exit', side_effect=ExitException) as mock_exit:
@@ -38,7 +39,8 @@ class TestCli(object):
                      unittest.mock.call().dump(mock_event),
                      unittest.mock.call().post(mock_event),
                      unittest.mock.call().dump(mock_event),
-                     unittest.mock.call().post(mock_event)]
+                     unittest.mock.call().post(mock_event),
+                     unittest.mock.call().finish()]
             print(mock_esl.method_calls)
             nose.tools.ok_(mock_esl.method_calls == calls)
 
@@ -54,6 +56,7 @@ class TestCli(object):
     @unittest.mock.patch('es_logger.EsLogger', autospec=True)
     def test_console_length(self, mock_esl):
         mock_esl(0, []).events = []
+        mock_esl(0, []).finish.return_value = 0
         sys.argv = ['es-logger', '-c', '1000', '-e']
         with unittest.mock.patch('sys.exit', side_effect=ExitException()) as mock_exit:
             nose.tools.assert_raises(ExitException, es_logger.cli.main)
@@ -69,6 +72,7 @@ class TestCli(object):
         mock_es_info = unittest.mock.MagicMock()
         mock_esl(console_length=DEFAULT_CONSOLE_LENGTH, targets=[]).es_info = mock_es_info
         mock_esl(console_length=DEFAULT_CONSOLE_LENGTH, targets=[]).post.return_value = 0
+        mock_esl(console_length=DEFAULT_CONSOLE_LENGTH, targets=[]).finish.return_value = 0
         mock_esl(console_length=DEFAULT_CONSOLE_LENGTH, targets=[]).events = [mock_event,
                                                                               mock_event]
         with unittest.mock.patch('sys.exit', side_effect=ExitException) as mock_exit:
@@ -80,7 +84,8 @@ class TestCli(object):
                      unittest.mock.call().dump(mock_event),
                      unittest.mock.call().post(mock_event),
                      unittest.mock.call().dump(mock_event),
-                     unittest.mock.call().post(mock_event)]
+                     unittest.mock.call().post(mock_event),
+                     unittest.mock.call().finish()]
             print(mock_esl.method_calls)
             nose.tools.ok_(mock_esl.method_calls == calls, "Calls made don't match expected")
 

--- a/test/test_es_logger.py
+++ b/test/test_es_logger.py
@@ -241,3 +241,14 @@ class TestEsLogger(object):
     def test_post_bad(self):
         status = self.esl.post(None)
         nose.tools.ok_(status == 1)
+
+    def test_finish(self):
+        status = self.esl.finish()
+        nose.tools.ok_(status == 0)
+
+    def test_finish_bad(self):
+        mock_target = unittest.mock.MagicMock()
+        mock_target.driver.finish_send.return_value = 1
+        self.esl.targets = [mock_target, mock_target]
+        status = self.esl.finish()
+        nose.tools.ok_(status == 2)

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -72,3 +72,4 @@ class TestPlugins(object):
         nose.tools.assert_is_instance(help_str, str)
         et = DummyEventTarget()
         et.send_event({'es_logger': True})
+        et.finish_send()


### PR DESCRIPTION
Some event targets may want to batch events rather than relying on
http(s) sessions for efficiencies.  Add the concept of finishing a
send to the framework to cater for this.