### PR TITLE
Add a ZMQ client for the Jenkins ZMQ plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ script:
   - tox -e $TOX_ENV
 jobs:
   include:
-    - stage: test
-      python: 3.6
-      env:
-        - TOX_ENV=py36
     - &main-env
       python: 3.7
       dist: xenial

--- a/es_logger/cli.py
+++ b/es_logger/cli.py
@@ -83,8 +83,7 @@ def main():
         sys.exit(0)
 
     esl = es_logger.EsLogger(console_length=args.console_length, targets=args.target)
-    esl.get_build_data()
-    esl.get_events()
+    esl.gather_all()
 
     status = 0
     # Loop over all of the events to send,

--- a/es_logger/plugins/target.py
+++ b/es_logger/plugins/target.py
@@ -4,8 +4,11 @@
 __author__ = 'jonpsull'
 
 from ..interface import EventTarget
+import logging
 import os
 import requests
+
+LOGGER = logging.getLogger(__name__)
 
 
 class LogstashTarget(EventTarget):
@@ -40,6 +43,7 @@ Logstash Target Environment Variables:
     def send_event(self, json_event):
         session = self.get_session()
         r = session.post(self.logstash_server, json=json_event)
+        LOGGER.debug("Posted event, result {}".format(r.ok))
         if r.ok:
             return 0
         return 1
@@ -61,6 +65,7 @@ Logstash Target Environment Variables:
 
     def get_session(self):
         if self.ls_session is None:
+            LOGGER.debug("Creating session against {}".format(self.logstash_server))
             self.ls_session = requests.Session()
             self.ls_session.auth = (self.ls_user, self.ls_password)
         return self.ls_session

--- a/es_logger/zmq_client.py
+++ b/es_logger/zmq_client.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2018 Cisco Systems, Inc.
+# All rights reserved.
+
+__author__ = 'jonpsull'
+
+import asyncio
+import configparser
+import es_logger
+import json
+import logging
+import os
+import signal
+import sys
+import urllib
+import zmq
+from zmq.asyncio import Context
+
+
+# Configure logging for the daemon
+def configure_logging(debug=False):  # pragma: no cover
+    if debug:
+        log_level = logging.DEBUG
+    else:
+        log_level = logging.INFO
+
+    logging.basicConfig(level=log_level,
+                        format='%(asctime)s %(name)s %(levelname)s %(message)s')
+
+
+# Base Exception Class
+class ZMQClientError(Exception):
+    pass
+
+
+# Misconfiguration exception class
+class ZMQClientMisconfiguration(ZMQClientError):
+    pass
+
+
+# Class for running es-logger as Jenkins ZMQ listener
+class ESLoggerZMQDaemon(object):
+    def __init__(self):
+        self.listener = None
+        self.tasks = []
+        self.env_vars = ['JENKINS_URL', 'JENKINS_USER', 'JENKINS_PASSWORD', 'PROCESS_CONSOLE_LOGS',
+                         'GATHER_BUILD_DATA', 'GENERATE_EVENTS', 'LOGSTASH_SERVER', 'LS_USER',
+                         'LS_PASSWORD']
+        self.process_console_logs = ''
+        self.gather_build_data = ''
+        self.generate_events = ''
+
+    # Read the configuration
+    def configure(self, config_file='es-logger.ini'):
+        config = configparser.ConfigParser()
+        config.read(config_file)
+
+        if 'zmq' in config:
+            self.num_workers = config['zmq'].get('num_workers', 3)
+            self.zmq_publisher = config['zmq'].get('zmq_publisher')
+
+        if 'jenkins' in config:
+            self.jenkins_url = config['jenkins'].get('jenkins_url')
+            self.jenkins_user = config['jenkins'].get('jenkins_user')
+            self.jenkins_password = config['jenkins'].get('jenkins_password')
+
+        if 'plugins' in config:
+            process_console_logs = ' '.join(
+                es_logger.EsLogger.list_plugins(True, ['process_console_logs']))
+            self.process_console_logs = config['plugins'].get('process_console_logs',
+                                                              process_console_logs)
+            gather_build_data = ' '.join(
+                es_logger.EsLogger.list_plugins(True, ['gather_build_data']))
+            self.gather_build_data = config['plugins'].get('gather_build_data', gather_build_data)
+            event_generator = ' '.join(es_logger.EsLogger.list_plugins(True, ['event_generator']))
+            self.generate_events = config['plugins'].get('generate_events', event_generator)
+
+        if 'logstash' in config:
+            self.logstash_server = config['logstash'].get('logstash_server')
+            self.ls_user = config['logstash'].get('ls_user')
+            self.ls_password = config['logstash'].get('ls_password')
+
+        self.validate_config()
+
+        # Set the necessary environment variables
+        for var in self.env_vars:
+            val = getattr(self, var.lower())
+            if val is not None and val is not '':
+                os.environ[var.upper()] = val
+
+    # Make sure we are correctly configured
+    def validate_config(self):
+        # Confirm configuration or raise an exception
+        unset_attr = []
+        for attr in ['jenkins_url', 'jenkins_user', 'jenkins_password',
+                     'logstash_server', 'zmq_publisher']:
+            if (not hasattr(self, attr)) or getattr(self, attr) is None:
+                unset_attr.append(attr)
+        if len(unset_attr) > 0:
+            e = ZMQClientMisconfiguration(
+                "Unconfigured for daemon operation, check config "
+                "for the following variables:\n{}".format(unset_attr))
+            raise(e)
+
+    # Strip off trailing slashes, and remove each "job" path element
+    @staticmethod
+    def get_project_name(job):
+        project = urllib.parse.urlsplit(job).path
+        # Ensure no trailing slash
+        project = project.rstrip('/')
+        # Ensure no job elements in path, as python-jenkins expects to add them
+        project = '/'.join([p for p in project.split('/') if p != 'job'])
+        return project
+
+    # Processing function to run es-logger
+    def es_logger_task(self, msg):
+        var = json.loads(''.join(msg[0].decode("utf-8").split()[1:]))
+        phase = var['build'].get('phase')
+        if phase == 'FINISHED':
+            job = self.get_project_name(var['url'])
+            number = var['build'].get('number')
+            logging.debug("Process {} number {} on {}".format(job, number, self.jenkins_url))
+            # Create and configure the ES-Logger instance
+            esl = es_logger.EsLogger(console_length=32500, targets=['logstash'])
+            esl.es_job_name = job
+            esl.es_build_number = int(number)
+            esl.gather_all()
+            status = esl.post_all()
+            logging.debug("{} number {} status {}".format(job, number, status))
+        else:
+            logging.debug('Not collecting from job in phase {}'.format(phase))
+            status = None
+        return status
+
+    # Worker to pull tasks off queue, process message, and execute
+    async def worker(self, name):
+        logging.info("{} Starting".format(name))
+        current_task = asyncio.current_task()
+        while not current_task.done():
+            try:
+                logging.debug("{} waiting for work".format(name))
+                msg = await asyncio.wait_for(self.queue.get(), 15)
+                logging.info("{} processing msg {}".format(name, msg))
+                result = self.es_logger_task(msg)
+                self.queue.task_done()
+                logging.debug("{} result {}".format(name, result))
+            except asyncio.TimeoutError:
+                logging.debug("{} timeout waiting for work, looping".format(name))
+            except asyncio.CancelledError:
+                logging.debug("{} cancelled, finishing".format(name))
+                break
+        logging.info("{} Finished".format(name))
+        return 0
+
+    # Drain the queue to enable clean shutdown
+    async def drain_queue(self):
+        logging.info("Draining queue")
+        status_list = []
+        while self.queue.qsize() != 0:
+            logging.debug("Queue of size {}".format(self.queue.qsize()))
+            msg = self.queue.get_nowait()
+            logging.info("Processing msg {}".format(msg))
+            result = self.es_logger_task(msg)
+            self.queue.task_done()
+            logging.debug("Result {}".format(result))
+            if result is not None:
+                status_list.append(result)
+        logging.info("Queue drained, size {}".format(self.queue.qsize()))
+        return status_list
+
+    # Connection function executed as listener task
+    async def recv(self):
+        logging.info('Listener Starting against {}'.format(self.zmq_publisher))
+        # Connect to ZMQ
+        ctx = Context.instance()
+        s = ctx.socket(zmq.SUB)
+        s.connect(self.zmq_publisher)
+        s.subscribe(b'')
+
+        current_task = asyncio.current_task()
+        while not current_task.done():
+            try:
+                logging.debug("Listener waiting for message")
+                msg = await asyncio.wait(s.recv_multipart())
+                logging.debug("Adding {} to queue {}".format(msg, self.queue.qsize()))
+                await self.queue.put(msg)
+            except asyncio.CancelledError:
+                logging.debug("Listener cancelled, finishing")
+                break
+        s.close()
+        logging.info("Listener Finished")
+
+    # Start the threads for processing
+    def start(self):
+        logging.info('Starting')
+        # Setup signal handlers
+        self.loop = asyncio.get_running_loop()
+        for signame in ('SIGINT', 'SIGTERM'):
+            self.loop.add_signal_handler(getattr(signal, signame), self.stop)
+        self.queue = asyncio.Queue()
+        # Create an asynchronous listener task
+        self.listener = asyncio.create_task(self.recv())
+        # Create worker tasks to process the queue concurrently.
+        self.tasks = []
+        for i in range(self.num_workers):
+            task = asyncio.create_task(self.worker(f'worker-{i}'))
+            self.tasks.append(task)
+        logging.debug(f'Started {self.num_workers} workers')
+
+    # Cancel the threads for stopping
+    def stop(self):
+        if self.listener is not None:
+            logging.debug("Stopping listener")
+            self.listener.cancel()
+        if len(self.tasks) > 0:
+            logging.debug("Stopping tasks")
+            for task in self.tasks:
+                task.cancel()
+        all_tasks = asyncio.Task.all_tasks()
+        logging.debug("All Tasks: {}".format(all_tasks))
+        logging.info("Stopped, waiting for tasks to finish")
+
+    # Check a task is in a good state
+    def check_task(self, task):
+        if task.done():
+            return False
+        return True
+
+    # Check that the listener is still running correctly
+    def check_listener(self):
+        logging.debug(self.listener)
+        return self.check_task(self.listener)
+
+    # Check that worker tasks are still running
+    def check_tasks(self):
+        logging.debug(self.tasks)
+        for task in self.tasks:
+            if not self.check_task(task):
+                return False
+        return True
+
+    # Return a list of all tasks started
+    def all_tasks(self):
+        return [self.listener] + self.tasks
+
+    # Boolean declaring whether all tasks are done or not
+    def tasks_done(self):
+        for task in self.all_tasks():
+            if not task.done():
+                return False
+        return True
+
+    # The ASync executed main function to control lifecycle
+    async def async_main(self):
+        # Start, monitor, then stop
+        self.start()
+        # Give some time to start up (also helps tests run faster)
+        await asyncio.sleep(2)
+        logging.info("Started tasks, entering status check loop")
+        while not self.tasks_done():
+            self.check_listener()
+            self.check_tasks()
+            await asyncio.sleep(30)
+
+        logging.info("Exited status check loop")
+
+        # Ensure all the tasks get completed
+        drain_status = await self.drain_queue()
+
+        # Wait for all of the coroutines to finish and gather the result
+        logging.info("Gathering task statuses")
+        status_list = await asyncio.gather(*([self.listener] + self.tasks), return_exceptions=True)
+        status_list = status_list + drain_status
+        status = 0
+        for s in status_list:
+            if isinstance(s, Exception):
+                logging.warning("Exception: {}".format(s))
+                status += 1
+            elif isinstance(s, int):
+                status += s
+            else:
+                logging.warning("Unknown status: {}".format(s))
+                status += 1
+        return status
+
+    # Synchronous main to trigger async main only,
+    # after loading configuration and setting environment
+    def main(self):
+        self.configure()
+        status = asyncio.run(self.async_main())
+        logging.info("Finished")
+        return status
+
+
+# Shouldn't need individual unit testing, keep as simple as possible
+def main():  # pragma: no cover
+    configure_logging()
+    d = ESLoggerZMQDaemon()
+    status = d.main()
+    sys.exit(status)

--- a/run_tests.bash
+++ b/run_tests.bash
@@ -6,4 +6,4 @@
 export PATH=${PATH}:~/.local/bin
 pip install -q --user -r test-requirements.txt
 
-$HOME/.local/bin/tox --workdir /tmp
+$HOME/.local/bin/tox --workdir /tmp "${@}"

--- a/samples/elasticsearch-template-es6x.json
+++ b/samples/elasticsearch-template-es6x.json
@@ -1,0 +1,46 @@
+{
+  "template" : "logstash-*",
+  "version" : 60001,
+  "settings" : {
+    "index.refresh_interval" : "5s",
+    "index.mapping.total_fields.limit": 3000
+  },
+  "mappings" : {
+    "_default_" : {
+      "dynamic_templates" : [ {
+        "message_field" : {
+          "path_match" : "message",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "text",
+            "norms" : false
+          }
+        }
+      }, {
+        "string_fields" : {
+          "match" : "*",
+          "match_mapping_type" : "string",
+          "mapping" : {
+            "type" : "text", "norms" : false,
+            "fields" : {
+              "keyword" : { "type": "keyword", "ignore_above": 256 }
+            }
+          }
+        }
+      } ],
+      "properties" : {
+        "@timestamp": { "type": "date"},
+        "@version": { "type": "keyword"},
+        "geoip"  : {
+          "dynamic": true,
+          "properties" : {
+            "ip": { "type": "ip" },
+            "location" : { "type" : "geo_point" },
+            "latitude" : { "type" : "half_float" },
+            "longitude" : { "type" : "half_float" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/samples/es-logger_logstash_sample.conf
+++ b/samples/es-logger_logstash_sample.conf
@@ -23,7 +23,7 @@ output {
         hosts => ["localhost:9200"]
         # Including env vars and parameters can create a large number of fields
         # see the associated logstash template
-        template => "/etc/logstash/elasticsearch-template-es5x.json"
+        template => "/etc/logstash/elasticsearch-template-es6x.json"
         template_overwrite => true
     }
 }

--- a/samples/es-logger_sample.ini
+++ b/samples/es-logger_sample.ini
@@ -1,0 +1,16 @@
+[zmq]
+num_workers = 3
+zmq_publisher = tcp://jenkins.example.com:8888
+
+[jenkins]
+jenkins_url = https://jenkins.example.com
+jenkins_user = xxx
+jenkins_password = xxx
+
+[plugins]
+generate_events = ansible_recap_v2 commit junit
+
+[logstash]
+logstash_server = http://1.2.3.4:8080
+ls_user = xxx
+ls_password = xxx

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'python-jenkins>=1.0.0',
         'requests',
         'stevedore',
+        'zmq',
     ],
 
     platforms=['Any'],
@@ -64,6 +65,7 @@ setup(
     entry_points={
         'console_scripts': [
             'es-logger=es_logger.cli:main',
+            'zmq-es-logger=es_logger.zmq_client:main',
         ],
         'es_logger.plugins.console_log_processor': [
         ],

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -32,8 +32,7 @@ class TestCli(object):
             nose.tools.assert_raises(ExitException, es_logger.cli.main)
             mock_exit.assert_called_with(0)
             calls = [unittest.mock.call.get_event_target_plugin_help(),
-                     unittest.mock.call().get_build_data(),
-                     unittest.mock.call().get_events(),
+                     unittest.mock.call().gather_all(),
                      unittest.mock.call().dump(mock_es_info),
                      unittest.mock.call().post(mock_es_info),
                      unittest.mock.call().dump(mock_event),
@@ -79,8 +78,7 @@ class TestCli(object):
             nose.tools.assert_raises(ExitException, es_logger.cli.main)
             mock_exit.assert_called_with(0)
             calls = [unittest.mock.call.get_event_target_plugin_help(),
-                     unittest.mock.call().get_build_data(),
-                     unittest.mock.call().get_events(),
+                     unittest.mock.call().gather_all(),
                      unittest.mock.call().dump(mock_event),
                      unittest.mock.call().post(mock_event),
                      unittest.mock.call().dump(mock_event),

--- a/test/test_zmq_client.py
+++ b/test/test_zmq_client.py
@@ -1,0 +1,410 @@
+# Copyright (c) 2018 Cisco Systems, Inc.
+# All rights reserved.
+
+__author__ = 'jonpsull'
+
+import asyncio
+import es_logger
+import nose
+import os
+import unittest.mock
+
+
+class TestZMQClient(object):
+    config_dict = {}
+    sample_completed_message = '''onFinalized {"name":"sample-job",
+        "url":"job/folder/job/sample-job/","build":{
+        "full_url":"https://joc.example.com/jenkins/jenkins_url/job/folder/job/sample-job/123/",
+        "number":123,"phase":"COMPLETED","status":"SUCCESS","url":"job/folder/job/sample-job/123/",
+        "node_name":"","node_description":"the master Jenkins node",
+        "host_name":"jenkins_url"}}'''.encode('ascii')
+    sample_completed_message_log = 'b\'onFinalized {"name":"sample-job",\\n        ' +\
+        '"url":"job/folder/job/sample-job/","build":{\\n        "full_url":' +\
+        '"https://joc.example.com/jenkins/jenkins_url/job/folder/job/sample-job/123/",\\n' +\
+        '        "number":123,"phase":"COMPLETED","status":"SUCCESS","url":' +\
+        '"job/folder/job/sample-job/123/",\\n        "node_name":"","node_description":' +\
+        '"the master Jenkins node",\\n        "host_name":"jenkins_url"}}\''
+    sample_finished_message = '''onFinalized {"name":"sample-job",
+        "url":"job/folder/job/sample-job/","build":{
+        "full_url":"https://joc.example.com/jenkins/jenkins_url/job/folder/job/sample-job/123/",
+        "number":123,"phase":"FINISHED","status":"SUCCESS","url":"job/folder/job/sample-job/123/",
+        "node_name":"","node_description":"the master Jenkins node",
+        "host_name":"jenkins_url"}}'''.encode('ascii')
+    sample_finished_message_log = 'b\'onFinalized {"name":"sample-job",\\n        ' +\
+        '"url":"job/folder/job/sample-job/","build":{\\n        "full_url":' +\
+        '"https://joc.example.com/jenkins/jenkins_url/job/folder/job/sample-job/123/",\\n' +\
+        '        "number":123,"phase":"FINISHED","status":"SUCCESS","url":' +\
+        '"job/folder/job/sample-job/123/",\\n        "node_name":"","node_description":' +\
+        '"the master Jenkins node",\\n        "host_name":"jenkins_url"}}\''
+
+    def setup(self):
+        self.zmqd = es_logger.zmq_client.ESLoggerZMQDaemon()
+        self.loop = asyncio.new_event_loop()
+        self.loop.set_debug(True)
+        asyncio.set_event_loop(self.loop)
+
+    def get_config_item(self, name):
+        return self.config_dict[name]
+
+    def set_config_item(self, name, val):
+        self.config_dict[name] = val
+
+    def config_contains(self, name):
+        return name in self.config_dict
+
+    def config_setup(self, mock_config_parser):
+        config = mock_config_parser.return_value
+        config.__getitem__.side_effect = self.get_config_item
+        config.__setitem__.side_effect = self.set_config_item
+        config.__contains__.side_effect = self.config_contains
+        return config
+
+    def set_default_config(self, config):
+        config['jenkins'] = {}
+        config['jenkins']['jenkins_url'] = 'https://jenkins.example.com'
+        config['jenkins']['jenkins_user'] = 'jenkins_user'
+        config['jenkins']['jenkins_password'] = 'jenkins_password'
+        config['logstash'] = {}
+        config['logstash']['logstash_server'] = 'https://logstash.example.com:8080'
+        config['logstash']['ls_user'] = 'ls_user'
+        config['logstash']['ls_password'] = 'ls_password'
+        config['zmq'] = {}
+        config['zmq']['zmq_publisher'] = 'tcp://jenkins.example.com:8888'
+
+    def set_plugin_config(self, config):
+        config['plugins'] = {}
+        config['plugins']['process_console_logs'] = 'process_console_logs'
+        config['plugins']['gather_build_data'] = 'gather_build_data'
+        config['plugins']['generate_events'] = 'generate_events'
+
+    async def dummyTask(self, count, sleep=0, return_status=0, exception=None):
+        print(f"I am dummyTask {count}")
+        # Give 5 seconds to ensure the main loop drops into check status
+        if sleep > 0:
+            await asyncio.sleep(sleep)
+        if exception is not None:
+            raise exception
+        print(f"dummyTask {count} finishing")
+        return return_status
+
+    # Test call flow with good options
+    def test_zmq_client_configure(self):
+        with unittest.mock.patch('configparser.ConfigParser') as mock_config_parser:
+            config = self.config_setup(mock_config_parser)
+            self.set_default_config(config)
+            self.set_plugin_config(config)
+            self.zmqd.configure()
+            for key in self.zmqd.env_vars:
+                if hasattr(self.zmqd, key.lower()):
+                    nose.tools.ok_(os.environ[key] == getattr(self.zmqd, key.lower()))
+
+    @nose.tools.raises(es_logger.zmq_client.ZMQClientMisconfiguration)
+    def test_zmq_missing_config(self):
+        es_logger.zmq_client.ESLoggerZMQDaemon().configure()
+
+    def test_get_project_name(self):
+        project = es_logger.zmq_client.ESLoggerZMQDaemon.get_project_name("//job/foo/job/bar/")
+        nose.tools.ok_(project == '/foo/bar')
+
+    @unittest.mock.patch('es_logger.EsLogger', autospec=True)
+    def test_es_logger_task(self, mock_esl):
+        self.zmqd.jenkins_url = 'https://joc.example.com/jenkins/jenkins_url'
+        mock_esl_instance = mock_esl(32500, ['logstash'])
+        mock_esl_instance.post_all.return_value = 0
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            self.zmqd.es_logger_task([self.sample_finished_message])
+        nose.tools.assert_equal(cm.output,
+                                ['DEBUG:root:Process folder/sample-job number 123 on ' +
+                                 'https://joc.example.com/jenkins/jenkins_url',
+                                 'DEBUG:root:folder/sample-job number 123 status 0'])
+        esl_calls = [unittest.mock.call().gather_all(),
+                     unittest.mock.call().post_all()]
+        nose.tools.assert_equals(mock_esl.method_calls, esl_calls)
+
+    @unittest.mock.patch('es_logger.EsLogger', autospec=True)
+    def test_es_logger_task_not_finished(self, mock_esl):
+        self.zmqd.jenkins_url = 'https://joc.example.com/jenkins/jenkins_url'
+        mock_esl_instance = mock_esl(32500, ['logstash'])
+        mock_esl_instance.post_all.return_value = 0
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            self.zmqd.es_logger_task([self.sample_completed_message])
+        nose.tools.assert_equal(cm.output,
+                                ['DEBUG:root:Not collecting from job in phase COMPLETED'])
+        esl_calls = []
+        nose.tools.assert_equals(mock_esl.method_calls, esl_calls)
+
+    def test_worker(self):
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            status_list = asyncio.run(self.async_worker())
+        nose.tools.ok_(self.zmqd.queue.qsize() == 0)
+        nose.tools.ok_(status_list == [0])
+        self.zmqd.es_logger_task.assert_called_with(self.sample_finished_message)
+        nose.tools.assert_equal(
+            cm.output,
+            ['DEBUG:asyncio:Using selector: EpollSelector',
+             'INFO:root:worker-1 Starting',
+             'DEBUG:root:worker-1 waiting for work',
+             'INFO:root:worker-1 processing msg ' + self.sample_finished_message_log,
+             'DEBUG:root:worker-1 result 0',
+             'DEBUG:root:worker-1 waiting for work',
+             'DEBUG:root:worker-1 cancelled, finishing',
+             'INFO:root:worker-1 Finished'])
+
+    async def async_worker(self):
+        self.zmqd.queue = asyncio.Queue()
+        self.zmqd.es_logger_task = unittest.mock.MagicMock()
+        self.zmqd.es_logger_task.return_value = 0
+        task = asyncio.create_task(self.zmqd.worker(f'worker-1'))
+        self.zmqd.queue.put_nowait(self.sample_finished_message)
+        # Yield control to the worker task
+        await asyncio.sleep(1)
+        # Cancel the worker
+        task.cancel()
+        return await asyncio.gather(task, return_exceptions=True)
+
+    def test_worker_timeout(self):
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            status_list = asyncio.run(self.async_worker_timeout())
+        nose.tools.ok_(self.zmqd.queue.qsize() == 0)
+        nose.tools.ok_(status_list == [0])
+        nose.tools.assert_equal(
+            cm.output,
+            ['DEBUG:asyncio:Using selector: EpollSelector',
+             'INFO:root:worker-1 Starting',
+             'DEBUG:root:worker-1 waiting for work',
+             'DEBUG:root:worker-1 timeout waiting for work, looping',
+             'DEBUG:root:worker-1 waiting for work',
+             'DEBUG:root:worker-1 cancelled, finishing',
+             'INFO:root:worker-1 Finished'])
+
+    async def async_worker_timeout(self):
+        self.zmqd.queue = asyncio.Queue()
+        task = asyncio.create_task(self.zmqd.worker(f'worker-1'))
+        # Yield control to the worker task
+        await asyncio.sleep(16)
+        # Cancel the worker
+        task.cancel()
+        return await asyncio.gather(task, return_exceptions=True)
+
+    def test_drain_queue(self):
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            status_list = asyncio.run(self.async_drain_queue())
+        nose.tools.ok_(status_list == [0])
+        calls = [unittest.mock.call(self.sample_completed_message),
+                 unittest.mock.call(self.sample_finished_message)]
+        self.zmqd.es_logger_task.assert_has_calls(calls)
+        nose.tools.assert_equal(
+            cm.output,
+            ['DEBUG:asyncio:Using selector: EpollSelector',
+             'INFO:root:Draining queue',
+             'DEBUG:root:Queue of size 2',
+             'INFO:root:Processing msg ' + self.sample_completed_message_log,
+             'DEBUG:root:Result None',
+             'DEBUG:root:Queue of size 1',
+             'INFO:root:Processing msg ' + self.sample_finished_message_log,
+             'DEBUG:root:Result 0',
+             'INFO:root:Queue drained, size 0'])
+
+    async def async_drain_queue(self):
+        self.zmqd.es_logger_task = unittest.mock.MagicMock()
+        self.zmqd.es_logger_task.side_effect = [None, 0]
+        self.zmqd.queue = asyncio.Queue()
+        self.zmqd.queue.put_nowait(self.sample_completed_message)
+        self.zmqd.queue.put_nowait(self.sample_finished_message)
+        return await self.zmqd.drain_queue()
+
+    @unittest.mock.patch('es_logger.zmq_client.Context', autospec=True)
+    def test_recv(self, mock_context):
+        self.zmqd.zmq_publisher = 'tcp://jenkins.example.com:8888'
+        mc_instance = mock_context.instance()
+        self.zmqd.queue = asyncio.Queue()
+
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            listener = asyncio.run(self.async_recv(mc_instance))
+
+        nose.tools.assert_equal(
+            cm.output,
+            ['DEBUG:asyncio:Using selector: EpollSelector',
+             'INFO:root:Listener Starting against tcp://jenkins.example.com:8888',
+             'DEBUG:root:Listener waiting for message',
+             'DEBUG:root:Adding ({<Future finished result=1>}, set()) to queue 0',
+             'DEBUG:root:Listener waiting for message',
+             'DEBUG:root:Listener cancelled, finishing',
+             'INFO:root:Listener Finished'])
+        context_calls = [
+            unittest.mock.call.instance(),
+            unittest.mock.call.instance().socket(),
+            unittest.mock.call.instance(),
+            unittest.mock.call.instance().socket(2),
+            unittest.mock.call.instance().socket().connect('tcp://jenkins.example.com:8888'),
+            unittest.mock.call.instance().socket().subscribe(b'')]
+        mock_context.assert_has_calls(context_calls)
+        nose.tools.ok_(listener.done())
+
+    async def async_recv(self, mc_instance):
+        future_msg = asyncio.Future()
+        future_msg.set_result(1)
+        mc_instance.socket().recv_multipart.side_effect = [[future_msg], [asyncio.Future()]]
+        listener = asyncio.create_task(self.zmqd.recv())
+        await asyncio.sleep(1)
+        listener.cancel()
+        return listener
+
+    def test_start(self):
+        dummy_task = unittest.mock.MagicMock()
+        dummy_task.return_value = self.dummyTask(0)
+        self.zmqd.recv = dummy_task
+        self.zmqd.worker = dummy_task
+        self.zmqd.num_workers = 2
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            asyncio.run(self.async_start())
+        nose.tools.assert_equal(
+            cm.output,
+            ['DEBUG:asyncio:Using selector: EpollSelector',
+             'INFO:root:Starting',
+             'DEBUG:root:Started 2 workers'])
+        nose.tools.ok_(len(self.zmqd.tasks) == 2)
+        nose.tools.ok_(self.zmqd.listener)
+
+    async def async_start(self):
+        self.zmqd.start()
+
+    def test_stop(self):
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            asyncio.run(self.async_stop())
+        # Use the log messages to assert we cancelled the tasks
+        nose.tools.assert_regex(
+            '\n'.join(cm.output),
+            '\n'.join(
+                [r'DEBUG:asyncio:Using selector: EpollSelector',
+                 r'DEBUG:root:Stopping listener',
+                 r'DEBUG:root:Stopping tasks',
+                 r'DEBUG:root:All Tasks: {.*}',
+                 r'INFO:root:Stopped, waiting for tasks to finish']))
+
+    async def async_stop(self):
+        self.zmqd.listener = asyncio.create_task(self.dummyTask(1, sleep=5))
+        self.zmqd.tasks = [asyncio.create_task(self.dummyTask(2, sleep=5))]
+        return self.zmqd.stop()
+
+    # Tested as part of next 2 tests
+    def test_check_task(self):
+        pass
+
+    def test_check_listener(self):
+        self.zmqd.listener = unittest.mock.create_autospec(asyncio.Task)
+        self.zmqd.listener.done = unittest.mock.Mock(side_effect=[False, True])
+        task_status = self.zmqd.check_listener()
+        nose.tools.ok_(task_status)
+        task_status = self.zmqd.check_listener()
+        nose.tools.ok_(not task_status)
+
+    def test_check_tasks(self):
+        self.zmqd.tasks = [unittest.mock.create_autospec(asyncio.Task),
+                           unittest.mock.create_autospec(asyncio.Task)]
+        self.zmqd.tasks[0].done = unittest.mock.Mock(side_effect=[False, False, True])
+        self.zmqd.tasks[1].done = unittest.mock.Mock(side_effect=[False, True])
+        task_status = self.zmqd.check_tasks()
+        nose.tools.ok_(task_status)
+        task_status = self.zmqd.check_tasks()
+        nose.tools.ok_(not task_status)
+        task_status = self.zmqd.check_tasks()
+        nose.tools.ok_(not task_status)
+
+    def test_all_tasks(self):
+        self.zmqd.listener = unittest.mock.create_autospec(asyncio.Task)
+        self.zmqd.tasks = [unittest.mock.create_autospec(asyncio.Task)]
+        nose.tools.assert_equal(self.zmqd.all_tasks(), [self.zmqd.listener] + self.zmqd.tasks)
+
+    def test_tasks_done(self):
+        self.zmqd.listener = unittest.mock.create_autospec(asyncio.Task)
+        self.zmqd.tasks = [unittest.mock.create_autospec(asyncio.Task)]
+        self.zmqd.listener.done = unittest.mock.Mock(side_effect=[False, True, True])
+        self.zmqd.tasks[0].done = unittest.mock.Mock(side_effect=[False, True])
+        # No tasks done
+        tasks_done = self.zmqd.tasks_done()
+        nose.tools.ok_(not tasks_done)
+        # One task done
+        tasks_done = self.zmqd.tasks_done()
+        nose.tools.ok_(not tasks_done)
+        # All tasks done
+        tasks_done = self.zmqd.tasks_done()
+        nose.tools.ok_(tasks_done)
+
+    def test_async_main(self):
+        self.zmqd.queue = asyncio.Queue()
+        self.zmqd.check_listener = unittest.mock.MagicMock()
+        self.zmqd.check_tasks = unittest.mock.MagicMock()
+        self.zmqd.start = unittest.mock.MagicMock()
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            status = asyncio.run(self.async_async_main())
+        nose.tools.assert_equal(
+            cm.output,
+            ['DEBUG:asyncio:Using selector: EpollSelector',
+             'INFO:root:Started tasks, entering status check loop',
+             'INFO:root:Exited status check loop',
+             'INFO:root:Draining queue',
+             'INFO:root:Queue drained, size 0',
+             'INFO:root:Gathering task statuses'])
+        nose.tools.ok_(status == 0)
+
+    async def async_async_main(self):
+        self.zmqd.listener = asyncio.create_task(self.dummyTask(1, sleep=5))
+        self.zmqd.tasks = [asyncio.create_task(self.dummyTask(2, sleep=5))]
+        return await self.zmqd.async_main()
+
+    def test_async_main_unknown(self):
+        self.zmqd.queue = asyncio.Queue()
+        self.zmqd.start = unittest.mock.MagicMock()
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            status = asyncio.run(self.async_async_main_unknown())
+        nose.tools.assert_equal(
+            cm.output,
+            ['DEBUG:asyncio:Using selector: EpollSelector',
+             'INFO:root:Started tasks, entering status check loop',
+             'INFO:root:Exited status check loop',
+             'INFO:root:Draining queue',
+             'INFO:root:Queue drained, size 0',
+             'INFO:root:Gathering task statuses',
+             'WARNING:root:Unknown status: Bad return'])
+        nose.tools.ok_(status == 1)
+
+    async def async_async_main_unknown(self):
+        self.zmqd.listener = asyncio.create_task(self.dummyTask(1))
+        self.zmqd.tasks = [asyncio.create_task(self.dummyTask(2, return_status="Bad return"))]
+        return await self.zmqd.async_main()
+
+    def test_async_main_exception(self):
+        self.zmqd.queue = asyncio.Queue()
+        self.zmqd.start = unittest.mock.MagicMock()
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            status = asyncio.run(self.async_async_main_exception())
+        nose.tools.assert_equal(
+            cm.output,
+            ['DEBUG:asyncio:Using selector: EpollSelector',
+             'INFO:root:Started tasks, entering status check loop',
+             'INFO:root:Exited status check loop',
+             'INFO:root:Draining queue',
+             'INFO:root:Queue drained, size 0',
+             'INFO:root:Gathering task statuses',
+             'WARNING:root:Exception: Exception message'])
+        nose.tools.ok_(status == 1)
+
+    async def async_async_main_exception(self):
+        self.zmqd.listener = asyncio.create_task(self.dummyTask(1))
+        self.zmqd.tasks = [asyncio.create_task(
+            self.dummyTask(2, exception=Exception("Exception message")))]
+        return await self.zmqd.async_main()
+
+    @unittest.mock.patch('es_logger.zmq_client.asyncio', autospec=True)
+    def test_main(self, mock_asyncio):
+        with unittest.mock.patch('configparser.ConfigParser') as mock_config_parser:
+            config = self.config_setup(mock_config_parser)
+            self.set_default_config(config)
+            self.set_plugin_config(config)
+            mock_asyncio.run.return_value = 0
+            self.zmqd.async_main = unittest.mock.Mock()
+            status = self.zmqd.main()
+        print(mock_asyncio.mock_calls)
+        mock_asyncio.assert_has_calls([unittest.mock.call.run(self.zmqd.async_main())])
+        nose.tools.assert_equal(status, 0)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = flake8,py36,py37
+envlist = flake8,py37
 
 [tox:jenkins]
 skip_missing_interpreters = True


### PR DESCRIPTION
Enable execution of es-logger as a persistent client process that will
read messages from the ZMQ created by the Jenkins ZMQ plugin.