### PR TITLE
Fix main loop code

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,16 +48,17 @@ setup(
 
     install_requires=[
         'python-jenkins>=1.0.0',
+        'pyzmq',
         'requests',
         'stevedore',
-        'zmq',
     ],
 
     platforms=['Any'],
 
     scripts=[],
 
-    provides=['es_logger'],
+    provides=['es_logger',
+              'zmq_es_logger'],
 
     packages=find_packages(exclude=['docs', 'test']),
     include_package_data=True,


### PR DESCRIPTION
* Waiting on a single future should be done with wait_for.
  * Associated test fixes
* Add some point to the main loop checking threads are running
  * Make sure to exit if we're not listening for example
* Add some configurable timeouts to speed testing