### PR TITLE
Correctly note the dependency on Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
         'Topic :: Software Development :: Testing',
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 
     keywords='jenkins development elasticsearch logstash build',


### PR DESCRIPTION
The asyncio.run() function was new in 3.7, correspondingly, it will
not run on Python 3.6.