### PR TITLE
Unquote the url from the ZMQ stream

### DIFF
--- a/es_logger/zmq_client.py
+++ b/es_logger/zmq_client.py
@@ -121,6 +121,8 @@ class ESLoggerZMQDaemon(object):
         project = project.rstrip('/')
         # Ensure no job elements in path, as python-jenkins expects to add them
         project = '/'.join([p for p in project.split('/') if p != 'job'])
+        # Finally, unquote the string, as python-jenkins expects to url encode
+        project = urllib.parse.unquote(project)
         return project
 
     # Processing function to run es-logger


### PR DESCRIPTION
We get the url-encoded projhect string from the ZMQ stream and passing this
back into python-jenkins results in the job not being found, due to it
performing an urlencode on the project name.  Fix it.