### PR TITLE
Avoid object/value error if config.xml is not retreived

### DIFF
--- a/es_logger/__init__.py
+++ b/es_logger/__init__.py
@@ -345,11 +345,13 @@ class EsLogger(object):
         except jenkins.JenkinsException as jenkins_err:
             LOGGER.error("JenkinsException when attempting to get job config: {}".format(
                     jenkins_err))
-            self.es_info['job_config_info'] = "Unable to retrieve config.xml."
+            self.es_info['job_config_info'] = None
+            self.es_info['job_config_info_status'] = "Unable to retrieve config.xml."
 
         if self.job_xml_raw is not None:
             self.job_xml = ET.fromstring(self.job_xml_raw)
             self.es_info['job_config_info'] = self.get_pipeline_job_info()
+            self.es_info['job_config_info_status'] = "Retrieved config.xml."
 
         # Environment Variables
         self.env_vars = self.server.get_build_env_vars(self.es_job_name, self.es_build_number)

--- a/test/test_es_logger.py
+++ b/test/test_es_logger.py
@@ -273,12 +273,14 @@ class TestEsLogger(object):
             self.esl.get_build_data()
             mock_driver_mgr.assert_called_once()
 
-            # Job Config recorded
-            expetected_error_msg = "Unable to retrieve config.xml."
-            nose.tools.ok_(self.esl.es_info['job_config_info'] == expetected_error_msg,
+            # Job Config not recorded
+            expected_error_msg = "Unable to retrieve config.xml."
+            nose.tools.ok_(self.esl.es_info['job_config_info'] is None,
                            "'job_config_info' value {} not '{}'".format(
-                               self.esl.es_info['job_config_info'],
-                               expetected_error_msg))
+                               self.esl.es_info['job_config_info'], None))
+            nose.tools.ok_(self.esl.es_info['job_config_info_status'] == expected_error_msg,
+                           "'job_config_info_status' value {} not '{}'".format(
+                               self.esl.es_info['job_config_info_status'], expected_error_msg))
 
             # Console log recorded
             nose.tools.ok_(self.esl.es_info['console_log'] == 'log',


### PR DESCRIPTION
If we don't have permissions to read the job configuration we set the
job_config_info to a string indicating so.  This actually prevents the
ingestion of the main build value as the job_config_info value might
previously have been read and interpreted as an object.

Instead, set the job_config_info to None and introduce the
job_config_info_status key to indicate status.