### PR TITLE
Allow for input data to be empty strings

### DIFF
--- a/es_logger/__init__.py
+++ b/es_logger/__init__.py
@@ -265,7 +265,7 @@ class EsLogger(object):
     def get_process_console_logs(self):
         if not self.process_console_logs:
             process_console_logs = os.environ.get('PROCESS_CONSOLE_LOGS')
-            if process_console_logs is None:
+            if process_console_logs in [None, '']:
                 self.process_console_logs = []
             else:
                 self.process_console_logs = process_console_logs.split(' ')
@@ -274,7 +274,7 @@ class EsLogger(object):
     def get_gather_build_data(self):
         if not self.gather_build_data:
             gather_build_data = os.environ.get('GATHER_BUILD_DATA')
-            if gather_build_data is None:
+            if gather_build_data in [None, '']:
                 self.gather_build_data = []
             else:
                 self.gather_build_data = gather_build_data.split(' ')
@@ -283,7 +283,7 @@ class EsLogger(object):
     def get_generate_events(self):
         if not self.generate_events:
             generate_events = os.environ.get('GENERATE_EVENTS')
-            if generate_events is None:
+            if generate_events in [None, '']:
                 self.generate_events = []
             else:
                 self.generate_events = generate_events.split(' ')


### PR DESCRIPTION
When running in a Jenkinsfile, I have lots of the parameters defaulted to empty strings.

```
    parameters {
        string defaultValue: "", description: '<p>The "Full project name" from the project status page.</p>', name: 'ES_JOB_NAME', trim: true
        string defaultValue: "", description: '<p>The "BUILD_NUMBER" of the job to generate events from</p>', name: 'ES_BUILD_NUMBER', trim: true
        string defaultValue: "", description: '<p>Named ConsoleLogProcessor plugins to use in execution</p>', name: 'PROCESS_CONSOLE_LOGS', trim: true
        string defaultValue: "", description: 'Named GatherBuildData plugins to use in execution.', name: 'GATHER_BUILD_DATA', trim: true
        string defaultValue: "", description: 'Named EventGenerator plugins to use in execution', name: 'GENERATE_EVENTS', trim: true
        string defaultValue: "", description: 'ID to which the further action applies', name: 'FURTHER_ACTION_ID', trim: true
        text defaultValue: "", description: '<p>Yaml or json format description of the further action</p>', name: 'FURTHER_ACTION'
        string defaultValue: "", description: 'Remove extra log files from data_store', name: 'CLEAN_DATA_STORE', trim: true
        booleanParam defaultValue: false, description: 'If ticked, attempts to add a further action to a specific ID.', name: 'ADD_FURTHER_ACTION'

        string defaultValue: "", description: "", name: 'EXTRA_OPTS', trim: false
        string defaultValue: "http://ip:8080", description: "The address of the logstash server to push data to", name: "LOGSTASH_SERVER", trim: true
        string defaultValue: "${HUDSON_URL}", description: "The base URL for the Jenkins server to retrieve data from", name: "JENKINS_URL", trim: true

    }
```

This presents a problem in parsing plugins and events since these checks only account for "None" objects and not an empty string. This change fixes this.