### PR TITLE
Add protection around es_build_number usage

### DIFF
--- a/es_logger/zmq_client.py
+++ b/es_logger/zmq_client.py
@@ -192,7 +192,7 @@ class ESLoggerZMQDaemon(object):
             # configuration details
             esl = es_logger.EsLogger(console_length=32500, targets=self.targets.keys())
             esl.es_job_name = job
-            esl.es_build_number = int(number)
+            esl.es_build_number = '{}'.format(number)
             esl.gather_all()
             status = esl.post_all()
             logging.info("{} number {} status {}".format(job, number, status))

--- a/test/test_es_logger.py
+++ b/test/test_es_logger.py
@@ -142,12 +142,14 @@ class TestEsLogger(object):
             nose.tools.ok_(getter() == param,
                            "{} returned {} not {}".format(getter.__name__, getter(), param))
 
-    def test_get_es_build_number(self):
+    def test_get_es_build_number_default(self):
         # Recreate the esl to validate parameters aren't set and default is 0
         self.esl = es_logger.EsLogger(1000, ['dummy'])
         nose.tools.ok_(self.esl.es_build_number == '0',
                        "self.esl.es_build_number not 0: {} ({})".format(
                         self.esl.es_build_number, type(self.esl.es_build_number)))
+
+    def test_get_es_build_number(self):
         es_build_number = '999'
         # Validate correct value from env
         with unittest.mock.patch.dict('os.environ', {'ES_BUILD_NUMBER': es_build_number}):
@@ -162,6 +164,18 @@ class TestEsLogger(object):
                            "{} not returning {}, types: {} {}".format(
                            self.esl.es_build_number, es_build_number,
                            type(self.esl.es_build_number), type(es_build_number)))
+
+    def test_get_es_build_number_int(self):
+        es_build_number = '999'
+        # Validate that we convert an int to a string
+        self.esl.es_build_number = 999
+        with nose.tools.assert_logs(level='WARN') as cm:
+            nose.tools.ok_(self.esl.get_es_build_number() == es_build_number,
+                           "{} not returning {}, types: {} {}".format(
+                           self.esl.es_build_number, es_build_number,
+                           type(self.esl.es_build_number), type(es_build_number)))
+        nose.tools.assert_equal(cm.output,
+                                ['WARNING:es_logger:converting int es_build_number to string'])
 
     @parameterized.expand(['process_console_logs', 'gather_build_data', 'generate_events'])
     def test_get_plugin(self, param):

--- a/test/test_zmq_client.py
+++ b/test/test_zmq_client.py
@@ -275,6 +275,10 @@ class TestZMQClient(object):
         esl_calls = [unittest.mock.call().gather_all(),
                      unittest.mock.call().post_all()]
         nose.tools.assert_equals(mock_esl.method_calls, esl_calls)
+        nose.tools.ok_(type(mock_esl_instance.es_build_number) is not int,
+                       "es_build_number should not be an int: {}".format(
+                       type(mock_esl_instance.es_build_number)))
+        nose.tools.assert_equals(mock_esl_instance.es_build_number, '123')
 
     @unittest.mock.patch('es_logger.EsLogger', autospec=True)
     def test_es_logger_task_not_finished(self, mock_esl):


### PR DESCRIPTION
* Add tests to ensure we are setting and getting es_build_number as an int.
* Make all usage of es_build_number to go through get_es_build_number()
* Convert an int of es_build_number to a string through format