### PR TITLE
Change parameters to strings

### DIFF
--- a/es_logger/__init__.py
+++ b/es_logger/__init__.py
@@ -366,10 +366,9 @@ class EsLogger(object):
                     try:
                         # Prevent different jobs with the same parameter names creating
                         # conflicting types through auto typing in elasticsearch
-                        self.es_info.setdefault('parameters', {}).setdefault(
-                            self.es_job_name, {})[param['name']] = param['value']
-                        # Try to ensure the value is always seen as a string
+                        # by ensuring the value is always seen as a string
                         param['value'] = "{}".format(param['value'])
+                        self.es_info.setdefault('parameters', {})[param['name']] = param['value']
                     except KeyError:
                         LOGGER.debug("KeyError on {}".format(param))
                         continue

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ else:
 
 setup(
     name='es_logger',
-    version='4.' + BUILD_NUMBER,
+    version='5.' + BUILD_NUMBER,
 
     description='Framework for Creating Logstash events from Jenkins Jobs',
     long_description=long_description,

--- a/test/test_es_logger.py
+++ b/test/test_es_logger.py
@@ -292,7 +292,7 @@ es_logger.plugins.event_target:
                                "{} not {}: {}".format(k, v, self.esl.es_info))
 
             # Parameters pulled out
-            nose.tools.ok_(self.esl.es_info['parameters']['es_job_name'].get('param') == 'value',
+            nose.tools.ok_(self.esl.es_info['parameters'].get('param') == 'value',
                            "Parameter 'param' not 'value': {}".format(self.esl.es_info))
 
             # Prevent ES field explosion through rewrite of builds by branch name
@@ -334,7 +334,7 @@ es_logger.plugins.event_target:
                 'number': '1',
                 'url': 'url',
                 'actions': [{'_class': 'hudson.model.ParametersAction',
-                             'parameters': [{'name': 'param', 'value': 'value'}]},
+                             'parameters': [{'name': 'param', 'value': 1}]},
                             {'_class': 'hudson.plugins.git.util.BuildData',
                              'buildsByBranchName': {'b1': {'buildNumber': '1'},
                                                     'b2': {'buildNumber': '2'}},
@@ -358,8 +358,9 @@ es_logger.plugins.event_target:
             nose.tools.ok_(self.esl.es_info['console_log'] == 'log',
                            "console_log not 'log': {}".format(self.esl.es_info))
             # Parameters pulled out
-            nose.tools.ok_(self.esl.es_info['parameters']['es_job_name'].get('param') == 'value',
-                           "Parameter 'param' not 'value': {}".format(self.esl.es_info))
+            nose.tools.ok_(self.esl.es_info['parameters'].get('param') == '1',
+                           "Parameter 'param' not '1': {} {}".format(
+                           self.esl.es_info, type(self.esl.es_info['parameters'].get('param'))))
 
             # Prevent ES field explosion through rewrite of builds by branch name
             nose.tools.ok_(


### PR DESCRIPTION
* Ensure parameters are always pulled in as strings
* Do not put the job name into the parameters name, as we can't do
  wildcard searches on fields in elasticsearch