### PR TITLE
Enable retrieval of events from a build artefact

### DIFF
--- a/es_logger/plugins/artifact.py
+++ b/es_logger/plugins/artifact.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2020 Cisco Systems, Inc.
+# All rights reserved.
+
+__author__ = 'jonpsull'
+
+from es_logger.interface import EventGenerator
+import jenkins
+import json
+import logging
+import os
+
+LOGGER = logging.getLogger(__name__)
+
+
+class ArtifactEvent(EventGenerator):
+    '''
+    '''
+    def __init__(self):
+        super().__init__()
+        self.config_artifact = os.environ.get('ES_EVENT_ARTIFACT', 'es-logger-data.json')
+
+    def generate_events(self, esl):
+        """
+        Create the events to additionally push
+
+        :param esl: The es-logger calling this plugin
+        :type esl: object
+        :returns: list(obj)
+        """
+        data = None
+        artifact_saved = False
+        for artifact in esl.build_info['artifacts']:
+            if self.config_artifact == artifact['relativePath']:
+                artifact_saved = True
+                break
+        if artifact_saved:
+            try:
+                raw_data = esl.server.get_build_artifact(
+                    esl.es_job_name, esl.es_build_number, self.config_artifact)
+                try:
+                    data = json.loads(raw_data)
+                except json.decoder.JSONDecodeError as err:
+                    LOGGER.warn("JSONDecodeError when attempting to get {} artifact: {}".format(
+                        self.config_artifact, err))
+                    LOGGER.warn("Data: {}".format(raw_data))
+            except jenkins.JenkinsException as jenkins_err:
+                LOGGER.warn("JenkinsException when attempting to get {} artifact: {}".format(
+                    self.config_artifact, jenkins_err))
+
+        ret_data = []
+
+        if data is None:
+            LOGGER.info("No saved event data found in artifact {}".format(self.config_artifact))
+        else:
+            ret_data = data
+
+        LOGGER.debug("Data: {}".format(ret_data))
+        return ret_data

--- a/setup.py
+++ b/setup.py
@@ -76,14 +76,15 @@ setup(
         'es_logger.plugins.event_generator': [
             'ansible_fatal = es_logger.plugins.ansible:AnsibleFatalGenerator',
             'ansible_recap_v2 = es_logger.plugins.ansible:AnsibleRecapEvent',
+            'artifact_events = es_logger.plugins.artifact:ArtifactEvent',
             'commit = es_logger.plugins.commit:CommitEvent',
             'console_log_events = es_logger.plugins.console_log_events:ConsoleLogEvent',
             'junit = es_logger.plugins.junit:JUnitEvent',
             'stages = es_logger.plugins.stages:StageEvent',
         ],
         'es_logger.plugins.event_generator.console_log_events': [
-            'es_logger = es_logger.plugins.console_log_events:EsLoggerConsoleLogRegex',
             'ansible = es_logger.plugins.ansible:AnsibleConsoleLogRegex',
+            'es_logger = es_logger.plugins.console_log_events:EsLoggerConsoleLogRegex',
         ],
         'es_logger.plugins.event_target': [
             'logstash = es_logger.plugins.target:LogstashTarget',

--- a/test/test_artifact.py
+++ b/test/test_artifact.py
@@ -1,0 +1,102 @@
+# Copyright (c) 2018 Cisco Systems, Inc.
+# All rights reserved.
+
+__author__ = 'jonpsull'
+
+import es_logger
+from jenkins import JenkinsException
+import nose
+import unittest.mock
+
+
+class TestArtifactEvent(object):
+
+    def test_artifact_event_json_decode_error(self):
+        eg = es_logger.plugins.artifact.ArtifactEvent()
+        fields = eg.get_fields()
+        nose.tools.ok_(fields == es_logger.interface.EventGenerator.DEFAULT_FIELDS)
+
+        esl = unittest.mock.MagicMock()
+        esl.console_log = 'log'
+        esl.build_info = {'artifacts': [{'relativePath': 'es-logger-data.json'}]}
+        # Invalid json as not in []
+        esl.server.get_build_artifact.return_value = ('{"name": "event1"},'
+                                                      + '{"name": "event2"}')
+
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            events = eg.generate_events(esl)
+
+        nose.tools.ok_(events == [])
+        nose.tools.assert_equal(
+            cm.output,
+            ['WARNING:es_logger.plugins.artifact:JSONDecodeError when attempting to get '
+             + 'es-logger-data.json artifact: Extra data: line 1 column 19 (char 18)',
+             'WARNING:es_logger.plugins.artifact:Data: {"name": "event1"},{"name": "event2"}',
+             'INFO:es_logger.plugins.artifact:No saved event data found in artifact '
+             + 'es-logger-data.json',
+             'DEBUG:es_logger.plugins.artifact:Data: []'])
+
+    def test_artifact_event_jenkins_exception(self):
+        eg = es_logger.plugins.artifact.ArtifactEvent()
+        fields = eg.get_fields()
+        nose.tools.ok_(fields == es_logger.interface.EventGenerator.DEFAULT_FIELDS)
+
+        esl = unittest.mock.MagicMock()
+        esl.console_log = 'log'
+        esl.build_info = {'artifacts': [{'relativePath': 'es-logger-data.json'}]}
+        esl.server.get_build_artifact.side_effect = JenkinsException("Bad download")
+
+        with nose.tools.assert_logs(level='DEBUG') as cm:
+            events = eg.generate_events(esl)
+
+        nose.tools.ok_(events == [])
+        nose.tools.assert_equal(
+            cm.output,
+            ['WARNING:es_logger.plugins.artifact:JenkinsException when attempting to get '
+             + 'es-logger-data.json artifact: Bad download',
+             'INFO:es_logger.plugins.artifact:No saved event data found in artifact '
+             + 'es-logger-data.json',
+             'DEBUG:es_logger.plugins.artifact:Data: []'])
+
+    def test_artifact_event(self):
+        eg = es_logger.plugins.artifact.ArtifactEvent()
+        fields = eg.get_fields()
+        nose.tools.ok_(fields == es_logger.interface.EventGenerator.DEFAULT_FIELDS)
+
+        esl = unittest.mock.MagicMock()
+        esl.console_log = 'log'
+        esl.build_info = {'artifacts': [{'relativePath': 'es-logger-data.json'}]}
+        esl.server.get_build_artifact.return_value = ('[{"name": "event1"},'
+                                                      + '{"name": "event2"},'
+                                                      + '{"name": "event3"}]')
+
+        events = eg.generate_events(esl)
+        nose.tools.ok_(len(events) == 3,
+                       "Wrong number of events returned ({}): {}".format(len(events), events))
+        results = [{"name": "event1"}, {"name": "event2"}, {"name": "event3"}]
+
+        for idx, event in enumerate(events):
+            nose.tools.ok_(event == results[idx],
+                           "Bad event[{}] returned: {}".format(idx, events))
+
+    @unittest.mock.patch.dict('os.environ', {'ES_EVENT_ARTIFACT': 'random.json'})
+    def test_artifact_event_env_filename(self):
+        eg = es_logger.plugins.artifact.ArtifactEvent()
+        fields = eg.get_fields()
+        nose.tools.ok_(fields == es_logger.interface.EventGenerator.DEFAULT_FIELDS)
+
+        esl = unittest.mock.MagicMock()
+        esl.console_log = 'log'
+        esl.build_info = {'artifacts': [{'relativePath': 'random.json'}]}
+        esl.server.get_build_artifact.return_value = ('[{"name": "event1"},'
+                                                      + '{"name": "event2"},'
+                                                      + '{"name": "event3"}]')
+
+        events = eg.generate_events(esl)
+        nose.tools.ok_(len(events) == 3,
+                       "Wrong number of events returned ({}): {}".format(len(events), events))
+        results = [{"name": "event1"}, {"name": "event2"}, {"name": "event3"}]
+
+        for idx, event in enumerate(events):
+            nose.tools.ok_(event == results[idx],
+                           "Bad event[{}] returned: {}".format(idx, events))

--- a/test/test_es_logger.py
+++ b/test/test_es_logger.py
@@ -208,6 +208,7 @@ es_logger.plugins.console_log_processor:
 es_logger.plugins.event_generator:
 \tansible_fatal
 \tansible_recap_v2
+\tartifact_events
 \tcommit
 \tconsole_log_events
 \tjunit


### PR DESCRIPTION
* Look for es-logger-data.json in the build artifacts, and if found read as a
  list of json events to pass to the target
* Allow filename selection with the ES_EVENT_ARTIFACT environment variable