### PR TITLE
Print traceback on thread exception

### DIFF
--- a/es_logger/zmq_client.py
+++ b/es_logger/zmq_client.py
@@ -15,6 +15,7 @@ import os
 import signal
 from stevedore import driver
 import sys
+import traceback
 import urllib
 import zmq
 from zmq.asyncio import Context
@@ -356,7 +357,7 @@ class ESLoggerZMQDaemon(object):
         status = 0
         for s in status_list:
             if isinstance(s, Exception):
-                logging.warning("Exception: {}".format(s))
+                logging.warning("Exception: {}\n{}".format(s, traceback.print_tb(s.__traceback__)))
                 status += 1
             elif isinstance(s, int):
                 status += s

--- a/test/test_zmq_client.py
+++ b/test/test_zmq_client.py
@@ -563,7 +563,7 @@ class TestZMQClient(object):
              'INFO:root:Draining queue of size 0',
              'INFO:root:Queue drained, processed 0',
              'INFO:root:Gathering task statuses',
-             'WARNING:root:Exception: Exception message'])
+             'WARNING:root:Exception: Exception message\nNone'])
         nose.tools.ok_(status == 1)
 
     async def async_async_main_exception(self):


### PR DESCRIPTION
When we shutdown the zmq server, if we see an exception, try and print
the traceback so that the location of exceptions can be found and the code
made more robust.